### PR TITLE
Add new quickfix for missing placeholder metadata

### DIFF
--- a/src/decorate.ts
+++ b/src/decorate.ts
@@ -47,14 +47,14 @@ export class Decorator {
 			[pluralDecoration, []],
 		]);
 
-		for (const [key, message] of messageList?.messages) {
-			const hasMetadata = Array.from(messageList.metadata.keys()).filter((literal) => literal.value === ('@' + key.value));
+		for (const entry of messageList?.messageEntries) {
+			const hasMetadata = messageList.metadataEntries.filter((metadataEntry) => metadataEntry.key.value === ('@' + entry.key.value));
 			let metadata: Metadata | null = null;
 			if (hasMetadata.length > 0) {
-				metadata = messageList.metadata.get(hasMetadata[0])!;
+				metadata = hasMetadata[0].message as Metadata;
 			}
-			decorateMessage(message, metadata);
-			decorateMetadata(message, metadata);
+			decorateMessage(entry.message as Message, metadata);
+			decorateMetadata(entry.message as Message, metadata);
 		}
 
 
@@ -68,7 +68,7 @@ export class Decorator {
 					decorateMessage(submessage, metadata);
 				}
 			} else if (message instanceof Placeholder) {
-				decorateAt(message.placeholder.start, message.placeholder.end, placeholderDecoration);
+				decorateAt(message.start, message.end, placeholderDecoration);
 			} else if (message instanceof ComplexMessage) {
 				decorateAt(message.argument.start, message.argument.end, placeholderDecoration);
 				let complexDecoration = selectDecoration;

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -41,24 +41,24 @@ export class Diagnostics {
 			showErrorAt(error.start, error.end, error.value, vscode.DiagnosticSeverity.Error, DiagnosticCode.mismatchedBrackets);
 		}
 
-		for (const [key, message] of messageList?.messages) {
-			const hasMetadata = Array.from(messageList.metadata.keys()).filter((literal) => literal.value === ('@' + key.value));
+		for (const entry of messageList?.messageEntries) {
+			const hasMetadata = messageList.metadataEntries.filter((metadataEntry) => metadataEntry.key.value === ('@' + entry.key.value));
 			let metadata: Metadata | null = null;
 			if (hasMetadata.length > 0) {
-				metadata = messageList.metadata.get(hasMetadata[0])!;
+				metadata = hasMetadata[0].message as Metadata;
 			}
 
-			validateKey(key, metadata, messageList.isReference);
-			validateMessage(message, metadata);
-			validateMetadata(message, metadata);
+			validateKey(entry.key, metadata, messageList.isReference);
+			validateMessage(entry.message as Message, metadata);
+			validateMetadata(entry.message as Message, metadata);
 		}
 
-		for (const [key, metadata] of messageList?.metadata) {
-			const hasMessage = Array.from(messageList.messages.keys()).filter((literal) => '@' + literal.value === key.value);
+		for (const metadataKey of messageList?.metadataEntries.map((entry) => entry.key)) {
+			const hasMessage = messageList.messageEntries.filter((messageEntry) => '@' + messageEntry.key.value === metadataKey.value);
 			if (hasMessage.length === 0) {
-				showErrorAt(key.start,
-					key.end,
-					`Metadata for an undefined key. Add a message key with the name "${key.value.substring(1)}".`,
+				showErrorAt(metadataKey.start,
+					metadataKey.end,
+					`Metadata for an undefined key. Add a message key with the name "${metadataKey.value.substring(1)}".`,
 					vscode.DiagnosticSeverity.Error,
 					DiagnosticCode.metadataForMissingKey,
 				);
@@ -93,7 +93,7 @@ export class Diagnostics {
 					validateMessage(submessage, metadata);
 				}
 			} else if (message instanceof Placeholder) {
-				validatePlaceholder(message.placeholder, metadata);
+				validatePlaceholder(message, metadata);
 			} else if (message instanceof ComplexMessage) {
 				validatePlaceholder(message.argument, metadata);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ import * as vscode from 'vscode';
 import { CodeActions } from './codeactions';
 import { Decorator as Decorator } from './decorate';
 import { Diagnostics } from './diagnose';
-import { MessageList, Parser, StringMessage } from './messageParser';
+import { Literal, MessageList, Parser } from './messageParser';
 const snippetsJson = require("../snippets/snippets.json");
 const snippetsInlineJson = require("../snippets/snippets_inline.json");
 
@@ -65,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			{
 				provideCompletionItems(document, position, token, context) {
 					const messageTypeAtCursor = commonMessageList?.getMessageAt(document.offsetAt(position));
-					if (messageTypeAtCursor instanceof StringMessage) {
+					if (messageTypeAtCursor instanceof Literal) {
 						return completionsStringInline;
 					} else {
 						return completions;
@@ -97,7 +97,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		function parseAndDecorate(): MessageList {
 			let [messageList, errors] = parser.parse(editor!.document.getText())!;
 			decorator.decorate(editor!, messageList);
-			diagnostics.diagnose(editor!, messageList, errors);quickfixes.update(messageList);
+			diagnostics.diagnose(editor!, messageList, errors);
+			quickfixes.update(messageList);
 			return messageList;
 		}
 	}

--- a/src/messageParser.ts
+++ b/src/messageParser.ts
@@ -199,14 +199,10 @@ export class MessageList {
 	}
 
 	getMessageAt(offset: number): Message | Metadata | null {
-		const partsContaining = [...this.messageEntries, ...this.metadataEntries]
+		return [...this.messageEntries, ...this.metadataEntries]
 			.flatMap((entry) => [entry.key, entry.message])
-			.filter((value) => value.whereIs(offset) !== null);
-		if (partsContaining.length > 0) {
-			return partsContaining[0].whereIs(offset);
-		} else {
-			return null;
-		}
+			.map((message) => message.whereIs(offset))
+			.find((whereIs) => whereIs !== null) ?? null;
 	}
 }
 
@@ -228,11 +224,9 @@ export class Metadata {
 	) { }
 
 	whereIs(offset: number): Message | null {
-		const placeholdersContaining = this.placeholders.filter((placeholder) => placeholder.whereIs(offset) !== null);
-		if (placeholdersContaining.length > 0) {
-			return placeholdersContaining[0].whereIs(offset);
-		}
-		return null;
+		return this.placeholders
+			.map((placeholder) => placeholder.whereIs(offset))
+			.find((whereIs) => whereIs !== null) ?? null;
 	}
 }
 
@@ -310,12 +304,9 @@ export class CombinedMessage extends Message {
 
 	whereIs(offset: number): Message | null {
 		if (this.start < offset && offset < this.end) {
-			const partsContaining = this.parts.filter((part) => part.whereIs(offset) !== null);
-			if (partsContaining.length > 0) {
-				return partsContaining[0].whereIs(offset);
-			} else {
-				return this;
-			}
+			return this.parts
+				.map((part) => part.whereIs(offset))
+				.find((whereIs) => whereIs !== null) ?? this;
 		}
 		return null;
 	}
@@ -344,12 +335,10 @@ export class ComplexMessage extends Message {
 
 	whereIs(offset: number): Message | null {
 		if (this.start < offset && offset < this.end) {
-			const partsContaining = Array.from(this.messages.entries()).filter(([literal, message]) => literal.whereIs(offset) !== null || message.whereIs(offset) !== null);
-			if (partsContaining.length > 0) {
-				return partsContaining[0][0].whereIs(offset) ?? partsContaining[0][1].whereIs(offset);
-			} else {
-				return null;
-			}
+			return Array.from(this.messages.entries())
+				.flatMap(([literal, message]) => [literal, message])
+				.map((part) => part.whereIs(offset))
+				.find((whereIs) => whereIs !== null) ?? null;
 		}
 		return null;
 	}

--- a/src/messageParser.ts
+++ b/src/messageParser.ts
@@ -17,8 +17,8 @@ export class Parser {
 
 	parse(document: string): [MessageList, Literal[]] {
 		let isReference: boolean = false;
-		const messages = new Map<Key, Message>();
-		const metadata = new Map<Key, Metadata>();
+		const messages: MessageEntry[] = [];
+		const metadata: MessageEntry[] = [];
 
 		let nestingLevel = 0;
 		let inReferenceTag = false;
@@ -26,20 +26,23 @@ export class Parser {
 		let metadataLevel: number | null = null;
 		let metadataKey: Key | null = null;
 		let messageKey: Key | null = null;
-		let definedPlaceholders: Literal[] = [];
+		let definedPlaceholders: PlaceholderMetadata[] = [];
 		let errors: Literal[] = [];
 		let indentation: number | null = null;
+		let indentationCharacter: string | null = null;
+		let totalPlaceholderEnd: number | null = null;
 		visit(document, {
 			onObjectBegin: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => {
 				nestingLevel++;
 			},
 			onObjectProperty: (property: string, offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => {
-				const literal = new Key(property, offset + 1, offset + property.length + 1);
+				const key = new Key(property, offset + 1, offset + property.length + 1);
 				if (placeholderLevel === nestingLevel - 1) {
-					definedPlaceholders.push(literal);
+					definedPlaceholders.push(new PlaceholderMetadata(property, offset + 1, offset + property.length + 1));
 				}
 				if (nestingLevel === 1) {
 					indentation = startCharacter;
+					indentationCharacter = document.substring(offset - 1, offset);
 					const isMetadata = property.startsWith('@');
 					if (isMetadata) {
 						const isGlobalMetadata = property.startsWith('@@');
@@ -48,11 +51,11 @@ export class Parser {
 								inReferenceTag = true;
 							}
 						} else {
-							metadataKey = literal;
+							metadataKey = key;
 							metadataLevel = nestingLevel;
 						}
 					} else {
-						messageKey = literal;
+						messageKey = key;
 					}
 				}
 				if (metadataLevel === nestingLevel - 1 && property === 'placeholders') {
@@ -66,7 +69,7 @@ export class Parser {
 				} else if (nestingLevel === 1 && messageKey !== null) {
 					try {
 						var message = parseMessage(value, offset, false);
-						messages.set(messageKey!, message);
+						messages.push(new MessageEntry(messageKey!, message));
 					} catch (error: any) {
 						//Very hacky solution to catch all errors here and store them, but better than not checking at all... The error has no special type, unfortunately.
 						if (String(error).startsWith('Error: Unbalanced ')) {
@@ -80,12 +83,15 @@ export class Parser {
 			},
 			onObjectEnd: (offset: number, length: number, startLine: number, startCharacter: number) => {
 				nestingLevel--;
-				if (placeholderLevel !== null && nestingLevel < placeholderLevel) {
-					placeholderLevel = null;
+				if (placeholderLevel !== null && nestingLevel === placeholderLevel + 1) {
+					definedPlaceholders[definedPlaceholders.length - 1].objectEnd = offset + length;
+				}
+				if (placeholderLevel !== null && nestingLevel === placeholderLevel) {
+					totalPlaceholderEnd = offset + length - 1;
 				}
 				if (metadataLevel !== null && nestingLevel <= metadataLevel) {
 					metadataLevel = -1;
-					metadata.set(metadataKey!, new Metadata([...definedPlaceholders]));
+					metadata.push(new MessageEntry(metadataKey!, new Metadata([...definedPlaceholders], offset, totalPlaceholderEnd ?? undefined)));
 					definedPlaceholders = [];
 					metadataKey = null;
 				}
@@ -97,11 +103,10 @@ export class Parser {
 			const vals = matchCurlyBrackets(messageString);
 
 			if (vals.length === 0) {
-				const literal = new Literal(messageString, globalOffset, globalOffset + messageString.length);
 				if (expectPlaceholder) {
-					return new Placeholder(literal);
+					return new Placeholder(messageString, globalOffset, globalOffset + messageString.length);
 				} else {
-					return new StringMessage(literal);
+					return new Literal(messageString, globalOffset, globalOffset + messageString.length);
 				}
 			}
 			const submessages: Message[] = [];
@@ -165,7 +170,7 @@ export class Parser {
 			}
 		}
 
-		return [new MessageList(isReference, indentation ?? 0, messages, metadata), errors];
+		return [new MessageList(isReference, indentation ?? 0, indentationCharacter ?? ' ', messages, metadata), errors];
 	}
 }
 function matchCurlyBrackets(value: string): XRegExp.MatchRecursiveValueNameMatch[] {
@@ -176,74 +181,113 @@ function matchCurlyBrackets(value: string): XRegExp.MatchRecursiveValueNameMatch
 	});
 }
 
-export class Literal {
+export class MessageList {
 	constructor(
-		public value: string,
-		public start: number,
-		public end: number
+		public isReference: boolean,
+		public indentation: number,
+		public indentationCharacter: string,
+		public messageEntries: MessageEntry[],
+		public metadataEntries: MessageEntry[],
 	) { }
 
-	public toString = (): string => {
-		return `Literal(${this.value},${this.start},${this.end})`;
-	};
+	getPlaceholders(): Literal[] {
+		return this.messageEntries.flatMap((messageEntry) => (messageEntry.message as Message).getPlaceholders());
+	}
 
-	whereIs(offset: number): Literal | Message | null {
-		if (this.start < offset && offset < this.end) {
-			return this;
+	getIndent(add?: number): string {
+		return this.indentationCharacter.repeat((this.indentation ?? 0) + (add ?? 0));
+	}
+
+	getMessageAt(offset: number): Message | Metadata | null {
+		const partsContaining = [...this.messageEntries, ...this.metadataEntries]
+			.flatMap((entry) => [entry.key, entry.message])
+			.filter((value) => value.whereIs(offset) !== null);
+		if (partsContaining.length > 0) {
+			return partsContaining[0].whereIs(offset);
 		} else {
 			return null;
 		}
 	}
 }
 
-export class MessageList {
+export class MessageEntry {
 	constructor(
-		public isReference: boolean,
-		public indentation: number,
-		public messages: Map<Key, Message>,
-		public metadata: Map<Key, Metadata>
-	) { }
-
-	getPlaceholders(): Literal[] {
-		return Array.from(this.messages.values()).flatMap((message) => message.getPlaceholders());
-	}
-
-	getMessageAt(offset: number): Message | Literal | Metadata | null {
-		const partsContaining = Array.from(this.messages.entries()).filter(([literal, message]) => literal.whereIs(offset) !== null || message.whereIs(offset) !== null);
-		if (partsContaining.length > 0) {
-			return partsContaining[0][0].whereIs(offset) ?? partsContaining[0][1].whereIs(offset);
-		} else {
-			return null;
-		}
+		public key: Key,
+		public message: Message | Metadata,
+	) {
+		message.parent = this;
 	}
 }
 
 export class Metadata {
 	constructor(
-		public placeholders: Literal[]
+		public placeholders: PlaceholderMetadata[],
+		public metadataEnd: number,
+		public lastPlaceholderEnd?: number,
+		public parent?: MessageEntry,
 	) { }
+
+	whereIs(offset: number): Message | null {
+		const placeholdersContaining = this.placeholders.filter((placeholder) => placeholder.whereIs(offset) !== null);
+		if (placeholdersContaining.length > 0) {
+			return placeholdersContaining[0].whereIs(offset);
+		}
+		return null;
+	}
 }
 
 export abstract class Message {
 	constructor(
 		public start: number,
 		public end: number,
+		public parent?: Message | MessageEntry,
 	) { }
 
 	abstract getPlaceholders(): Literal[];
 
-	abstract whereIs(offset: number): Message | Literal | null;
+	abstract whereIs(offset: number): Message | null;
+}
+
+export class Literal extends Message {
+	constructor(
+		public value: string,
+		public start: number,
+		public end: number,
+		parent?: Message | MessageEntry,
+	) {
+		super(start, end, parent);
+	}
+
+	public toString = (): string => {
+		return `Literal(${this.value},${this.start},${this.end})`;
+	};
+
+	whereIs(offset: number): Message | null {
+		if (this.start < offset && offset < this.end) {
+			return this;
+		} else {
+			return null;
+		}
+	}
+
+	getPlaceholders(): Literal[] {
+		return [];
+	}
 }
 
 export class Key extends Literal {
+	getPlaceholders(): Literal[] {
+		throw new Error('Method not implemented.');
+	}
 	endOfMessage?: number;
 
 	constructor(
 		value: string,
 		start: number,
 		end: number,
+		parent?: Message | MessageEntry,
 	) {
-		super(value, start, end);
+		super(value, start, end, parent);
 	}
 }
 
@@ -251,45 +295,29 @@ export class CombinedMessage extends Message {
 	constructor(
 		start: number,
 		end: number,
-		public parts: Message[]
+		public parts: Message[],
+		parent?: Message | MessageEntry,
 	) {
-		super(start, end);
+		super(start, end, parent);
+		for (const part of parts) {
+			part.parent = this;
+		}
 	}
 
 	getPlaceholders(): Literal[] {
 		return this.parts.flatMap((value) => value.getPlaceholders());
 	}
 
-	whereIs(offset: number): Literal | Message | null {
+	whereIs(offset: number): Message | null {
 		if (this.start < offset && offset < this.end) {
 			const partsContaining = this.parts.filter((part) => part.whereIs(offset) !== null);
 			if (partsContaining.length > 0) {
 				return partsContaining[0].whereIs(offset);
 			} else {
-				return null;
+				return this;
 			}
 		}
 		return null;
-	}
-}
-
-export class StringMessage extends Message {
-	constructor(
-		public value: Literal,
-	) {
-		super(value.start, value.end);
-	}
-
-	getPlaceholders(): Literal[] {
-		return [];
-	}
-
-	whereIs(offset: number): Literal | Message | null {
-		if (this.start < offset && offset < this.end) {
-			return this;
-		} else {
-			return null;
-		}
 	}
 }
 
@@ -299,16 +327,22 @@ export class ComplexMessage extends Message {
 		end: number,
 		public argument: Literal,
 		public complexType: Literal,
-		public messages: Map<Literal, Message>
+		public messages: Map<Literal, Message>,
+		parent?: Message | MessageEntry,
 	) {
-		super(start, end);
+		super(start, end, parent);
+		argument.parent = this;
+		complexType.parent = this;
+		for (const [_, message] of messages) {
+			message.parent = this;
+		}
 	}
 
 	getPlaceholders(): Literal[] {
 		return [this.argument, ...Array.from(this.messages.values()).flatMap((value) => value.getPlaceholders())];
 	}
 
-	whereIs(offset: number): Literal | Message | null {
+	whereIs(offset: number): Message | null {
 		if (this.start < offset && offset < this.end) {
 			const partsContaining = Array.from(this.messages.entries()).filter(([literal, message]) => literal.whereIs(offset) !== null || message.whereIs(offset) !== null);
 			if (partsContaining.length > 0) {
@@ -321,22 +355,53 @@ export class ComplexMessage extends Message {
 	}
 }
 
-export class Placeholder extends Message {
+export class Placeholder extends Literal {
 	constructor(
-		public placeholder: Literal
+		value: string,
+		start: number,
+		end: number,
+		parent?: Message | MessageEntry,
 	) {
-		super(placeholder.start, placeholder.end);
+		super(value, start, end, parent);
 	}
 
 	getPlaceholders(): Literal[] {
-		return [this.placeholder];
+		return [this];
 	}
 
-	whereIs(offset: number): Literal | Message | null {
+	whereIs(offset: number): Message | null {
 		if (this.start < offset && offset < this.end) {
 			return this;
 		} else {
 			return null;
 		}
+	}
+}
+export class PlaceholderMetadata extends Message {
+	constructor(
+		public value: string,
+		public start: number,
+		public end: number,
+		parent?: Message | MessageEntry,
+	) {
+		super(start, end, parent);
+	}
+
+	objectEnd: number | undefined;
+
+	public toString = (): string => {
+		return `Literal(${this.value},${this.start},${this.end})`;
+	};
+
+	whereIs(offset: number): Message | null {
+		if (this.start < offset && offset < this.end) {
+			return this;
+		} else {
+			return null;
+		}
+	}
+
+	getPlaceholders(): Literal[] {
+		return [];
 	}
 }

--- a/src/test/quickfix.arb
+++ b/src/test/quickfix.arb
@@ -1,6 +1,5 @@
 {
 	"@@locale": "en",
 	"@@x-reference": true,
-	"commonVehicleType": "A simple message",
-	"helloAndWelcome2": "Welcome {firstName} von {lastName}!",
+	"helloAndWelcome2": "Welcome!"
 }

--- a/src/test/quickfix.arb
+++ b/src/test/quickfix.arb
@@ -1,5 +1,6 @@
 {
-    "@@locale": "en",
-    "@@x-reference": true,
-    "commonVehicleType": "A simple message"
+	"@@locale": "en",
+	"@@x-reference": true,
+	"commonVehicleType": "A simple message",
+	"helloAndWelcome2": "Welcome {firstName} von {lastName}!",
 }

--- a/src/test/quickfix2.arb
+++ b/src/test/quickfix2.arb
@@ -1,0 +1,5 @@
+{
+	"@@locale": "en",
+	"helloAndWelcome2": "Welcome {firstName}!",
+	"@helloAndWelcome2": {}
+}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -77,8 +77,8 @@ suite('Extension Test Suite', async () => {
 		}`;
 		const [messages, errors] = new Parser().parse(document);
 		assert.equal(errors.length, 0);
-		assert.equal(messages.messages.size, 6);
-		assert.equal(messages.metadata.size, 5);
+		assert.equal(messages.messageEntries.length, 6);
+		assert.equal(messages.metadataEntries.length, 5);
 	});
 
 	test("Test quickfix", async () => {
@@ -87,12 +87,10 @@ suite('Extension Test Suite', async () => {
 		// Parse original
 		const [messageList, errors] = new Parser().parse(editor.document.getText());
 		const diagnostics = new Diagnostics().diagnose(editor, messageList, errors);
-		assert.equal(errors.length, 0);
-		assert.equal(messageList.messages.size, 1);
-		assert.equal(diagnostics.length, 1);
+		const numberOfDiagnostics = diagnostics.length;
 
 		// Apply fix
-		const messageKey = messageList.messages.keys().next().value as Key;
+		const messageKey = messageList.messageEntries[0].key as Key;
 		const actions = await vscode.commands.executeCommand<vscode.CodeAction[]>("vscode.executeCodeActionProvider",
 			editor.document.uri,
 			new vscode.Range(
@@ -104,9 +102,7 @@ suite('Extension Test Suite', async () => {
 		// Parse fixed
 		const [newMessageList, newErrors] = new Parser().parse(editor.document.getText());
 		const newDiagnostics = new Diagnostics().diagnose(editor, newMessageList, newErrors);
-		assert.equal(newErrors.length, 0);
-		assert.equal(newMessageList.messages.size, 1);
-		assert.equal(newDiagnostics.length, 0);
+		assert.equal(newDiagnostics.length, numberOfDiagnostics - 1);
 	});
 });
 


### PR DESCRIPTION
Also relates to #19.

Add a quickfix to add metadata to placeholders, if they are not declared in the metadata.