### PR TITLE
Allow decimalPatternDigits number format

### DIFF
--- a/schemas/arb.json
+++ b/schemas/arb.json
@@ -78,6 +78,7 @@
                                                 "compactLong",
                                                 "currency",
                                                 "decimalPattern",
+                                                "decimalPatternDigits",
                                                 "decimalPercentPattern",
                                                 "percentPattern",
                                                 "scientificPattern",


### PR DESCRIPTION
According to https://localizely.com/flutter-arb/ Flutter supports `decimalPatternDigits` as a number formatter in arb files. However, this plugin does not list that as a valid options in the JSON schema, so a warning with the label "Value is not accepted." is shown in the Problems panel in Vscode when the arb file contains this formatter name.
