### PR TITLE
[Refiled] Add `decimalPatternDigits` to the list of allowed formats

### DIFF
--- a/schemas/arb.json
+++ b/schemas/arb.json
@@ -78,6 +78,7 @@
                                                 "compactLong",
                                                 "currency",
                                                 "decimalPattern",
+                                                "decimalPatternDigits",
                                                 "decimalPercentPattern",
                                                 "percentPattern",
                                                 "scientificPattern",


### PR DESCRIPTION
Refile of #47 as requested by @mosuem.