### PR TITLE
Allow `isCustomDateFormat` to be a actual boolean

### DIFF
--- a/schemas/arb.json
+++ b/schemas/arb.json
@@ -117,10 +117,17 @@
                                             "description": "The formatters are the ones provided by the DateFormat class in Dart's package:intl."
                                         },
                                         "isCustomDateFormat": {
-                                            "type": "string",
-                                            "enum": [
-                                                "true",
-                                                "false"
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "true",
+                                                        "false"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
                                             ]
                                         },
                                         "example": {
@@ -142,8 +149,16 @@
                                             ],
                                             "properties": {
                                                 "isCustomDateFormat": {
-                                                    "type": "string",
-                                                    "const": "true"
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "const": "true"
+                                                        },
+                                                        {
+                                                            "type": "boolean",
+                                                            "const": true
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         },


### PR DESCRIPTION
Currently `isCustomDateFormat` can only be a boolean-like string, but a future version Flutter allow `isCustomDateFormat` to be an actual boolean.

Related 
- #56 
- #57 
- https://github.com/flutter/flutter/pull/153439

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR