### PR TITLE
Fix parser when value has backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "arbeditor" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+- Fix parser when value has backslash [#73](https://github.com/google/arb-editor/issues/73).
+
 ## [0.2.1]
 
 - Fix behavior of `use-escaping` [#72](https://github.com/google/arb-editor/issues/72).

--- a/src/test/testarb.annotated
+++ b/src/test/testarb.annotated
@@ -23,6 +23,8 @@
      ^^^^^^^^^[Information]:"The message with key "unescaped" does not have metadata defined."
     "singlequote": "Your pa''ssword",
      ^^^^^^^^^^^[Information]:"The message with key "singlequote" does not have metadata defined."
+    "unbalanced": "Your\tpa\u007Bssword",
+                   ^^^^^^^^^^^^^^^^^^^^[Error]:"Error: Unbalanced left delimiter found in string at position 7"
     "pageHomeInboxCount": "{count, plural, zero{I have {vehicle;;Type, select, sedn{Sedan} cabrolet{Solid roof cabriolet} tuck{16 wheel truck} other{Other}} no new messages} one{You have 1 new {counts} message} other{You have {count} new messages}}",
                             ^^^^^[decoration]placeholder
                                                         ^^^^^^^^^^^^^[decoration]placeholder
@@ -72,6 +74,17 @@
         "placeholders": {
             "vehicleType": {}
         }
+    },
+    "commonVehicleTypeUnicode": "\t\u0050{vehicleType, select  , sedan  {\u0053edan} cabriolet{Solid\troof cabriolet{\u0076ehicleName}} truck{16 wheel truck} other{Other}}",
+                                          ^^^^^^^^^^^[decoration]placeholder
+                                                                                                                     ^^^^^^^^^^^^^^^^[decoration]placeholder
+                                                                 ^^^^^[decoration]select
+                                                                                     ^^^^^^^^^[decoration]select
+                                                                                                                                        ^^^^^[decoration]select
+                                                                                                                                                              ^^^^^[decoration]select
+                                          ^^^^^^^^^^^[Warning]:"Placeholder "vehicleType" not defined in the message metadata."
+                                                                                                                     ^^^^^^^^^^^^^^^^[Warning]:"Placeholder "vehicleName" not defined in the message metadata."
+    "@commonVehicleTypeUnicode": {
     },
     "pageHomeBalance": "Your balance at {am[ount} on {date2}",
                                          ^^^^^^^[decoration]placeholder

--- a/src/test/testarb.arb
+++ b/src/test/testarb.arb
@@ -15,6 +15,7 @@
     "escaped": "Your pa'{'ssword",
     "unescaped": "Your pa'ssword",
     "singlequote": "Your pa''ssword",
+    "unbalanced": "Your\tpa\u007Bssword",
     "pageHomeInboxCount": "{count, plural, zero{I have {vehicle;;Type, select, sedn{Sedan} cabrolet{Solid roof cabriolet} tuck{16 wheel truck} other{Other}} no new messages} one{You have 1 new {counts} message} other{You have {count} new messages}}",
     "@pageHomeInboxCount": {
         "description": "New messages count on the Home screen",
@@ -37,6 +38,9 @@
         "placeholders": {
             "vehicleType": {}
         }
+    },
+    "commonVehicleTypeUnicode": "\t\u0050{vehicleType, select  , sedan  {\u0053edan} cabriolet{Solid\troof cabriolet{\u0076ehicleName}} truck{16 wheel truck} other{Other}}",
+    "@commonVehicleTypeUnicode": {
     },
     "pageHomeBalance": "Your balance at {am[ount} on {date2}",
     "@pageHomeBalance": {

--- a/src/test/testarb_2.annotated
+++ b/src/test/testarb_2.annotated
@@ -15,4 +15,4 @@
                 ^^^^^^^^^^^^^^^^[Error]:"Error: Unbalanced left delimiter found in string at position 8"
 }
 
-[Warning]:"Missing messages from template: unescaped, singlequote, pageHomeInboxCount, commonVehicleType, pageHomeBalance"
+[Warning]:"Missing messages from template: unescaped, singlequote, pageHomeInboxCount, commonVehicleType, commonVehicleTypeUnicode, pageHomeBalance"

--- a/src/test/testarb_3.annotated
+++ b/src/test/testarb_3.annotated
@@ -39,6 +39,15 @@
      ^^^^^^^^^^^^^^^^^[Information]:"The message with key "commonVehicleType" does not have metadata defined."
                            ^^^^^^^^^^^[Warning]:"Placeholder "vehicleType" not defined in the message metadata."
                                         ^^^^^^^[Error]:"Unknown ICU messagetype "se?lect""
+    "commonVehicleTypeUnicode": "\t\u0050{vehicleType, select  , sedan  {\u0053edan} cabriolet{Solid\troof cabriolet{\u0076ehicleName}} truck{16 wheel truck} other{Other}}",
+                                          ^^^^^^^^^^^[decoration]placeholder
+                                                                                                                     ^^^^^^^^^^^^^^^^[decoration]placeholder
+                                                                 ^^^^^[decoration]select
+                                                                                     ^^^^^^^^^[decoration]select
+                                                                                                                                        ^^^^^[decoration]select
+                                                                                                                                                              ^^^^^[decoration]select
+                                          ^^^^^^^^^^^[Warning]:"Placeholder "vehicleType" not defined in the message metadata."
+                                                                                                                     ^^^^^^^^^^^^^^^^[Warning]:"Placeholder "vehicleName" not defined in the message metadata."
     "pageHomeBalance": "Your balance at {am[ount} on {date2}"
                                          ^^^^^^^[decoration]placeholder
                                                       ^^^^^[decoration]placeholder

--- a/src/test/testarb_3.arb
+++ b/src/test/testarb_3.arb
@@ -11,5 +11,6 @@
     "pageHomeInboxCount": "{count, plural, zero{I have {vehicle;;Type, select, sedn{Sedan} cabrolet{Solid roof cabriolet} tuck{16 wheel truck} other{Other}} no new messages} one{You have 1 new {counts} message} other{You have {count} new messages}}",
     "pageHomeBirthday": "Today is {sex, sele{ct, male{his b{irthday} female{her birthday} other{their birthday}}.",
     "commonVehicleType": "{vehicleType, se?lect  , sedan  {Sedan} cabriolet{Solid roof cabriolet} truck{16 wheel truck} other{Other}}",
+    "commonVehicleTypeUnicode": "\t\u0050{vehicleType, select  , sedan  {\u0053edan} cabriolet{Solid\troof cabriolet{\u0076ehicleName}} truck{16 wheel truck} other{Other}}",
     "pageHomeBalance": "Your balance at {am[ount} on {date2}"
 }


### PR DESCRIPTION
Fixes #73

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR

I fixed to correctly parse strings containing backslashes.

**before**

![image](https://github.com/user-attachments/assets/2a0bbe54-0bb6-467d-ab35-b5573d704c22)


**after**

![image](https://github.com/user-attachments/assets/1ea6ebc9-2ae3-493f-b64c-8b9cf61e8579)
