### PR TITLE
Fix path traversal: contain template path within the workspace

### DIFF
--- a/src/messageParser.ts
+++ b/src/messageParser.ts
@@ -204,18 +204,39 @@ export class Parser {
 		document: vscode.TextDocument;
 		messageList: MessageList;
 	} & L10nYamlPathAndOptions): string | undefined {
+		let candidate: string | undefined;
 		if (messageList.templatePath) {
-			return path.isAbsolute(messageList.templatePath)
+			candidate = path.isAbsolute(messageList.templatePath)
 				? messageList.templatePath
 				: path.join(path.dirname(document.uri.fsPath), messageList.templatePath);
 		} else if (l10nOptions !== undefined) {
 			const templateRootFromOptions = l10nOptions?.['arb-dir'] ?? 'lib/l10n';
 			const templatePathFromOptions = l10nOptions?.['template-arb-file'] ?? 'app_en.arb';
 
-			return path.isAbsolute(templatePathFromOptions)
+			candidate = path.isAbsolute(templatePathFromOptions)
 				? templatePathFromOptions
 				: path.join(path.dirname(l10nYamlPath), templateRootFromOptions, templatePathFromOptions);
 		}
+
+		if (candidate === undefined) {
+			return undefined;
+		}
+
+		// Security: the template path is derived from workspace content that an
+		// untrusted party may control — the `@@x-template` field of an .arb file,
+		// or `arb-dir` / `template-arb-file` in l10n.yaml — and is passed straight
+		// to fs.readFileSync below. Without containment, a crafted value such as
+		// `@@x-template: "../../../../etc/passwd"` (or an absolute path) lets a
+		// repository read any file the editing user can open, outside the project.
+		// Refuse any resolved path that escapes the workspace folder.
+		const resolved = path.resolve(candidate);
+		const workspaceRoot = path.resolve(
+			vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath
+			?? path.dirname(document.uri.fsPath));
+		if (resolved !== workspaceRoot && !resolved.startsWith(workspaceRoot + path.sep)) {
+			return undefined;
+		}
+		return resolved;
 	}
 
 	parseAndDecorate({


### PR DESCRIPTION
Fixes #91.

### Problem

`Parser.resolveTemplatePath()` builds the template path from workspace-controlled content — the `@@x-template` field of an `.arb` file, or `arb-dir` / `template-arb-file` in `l10n.yaml` — and `parseAndDecorate()` passes it straight to `fs.readFileSync` (`src/messageParser.ts:243`). There is no `..` rejection and no workspace containment, and absolute paths are returned as-is. A crafted repository can therefore read any file the editing user can open, e.g.:

```json
{ "@@locale": "es", "@@x-template": "../../../../../../../../../../etc/passwd" }
```

For JSON-with-string-values targets, the file's top-level keys are then echoed into the Problems panel via the `Missing messages from template` diagnostic.

### Fix

Resolve the candidate path and reject anything that escapes the workspace folder, falling back to the edited document's own directory when there is no workspace folder. Both the `@@x-template` branch and the `l10n.yaml` branch now flow through the same containment check, so legitimate in-project templates keep working while escapes return `undefined` (no read).

### Testing

- `npm run compile` — passes
- `npm run lint` — passes
- Existing template-resolution fixtures (`with_x-template`, `arb-dir_template-arb-file`, `template-arb-file`) all resolve **inside** the test workspace, so they remain unaffected by the containment check.

I was not able to run the VS Code integration test suite in my environment (it downloads a VS Code build); please run `npm test` in CI to confirm.