### PR TITLE
Update schema so the metadata does not match two schemas (#93)

### DIFF
--- a/schemas/arb.json
+++ b/schemas/arb.json
@@ -336,7 +336,7 @@
                     "type": "string",
                     "description": "A short paragraph describing the resource and how it is being used by the app, and message that need to be passed to localization process and translators."
                 },
-                "comment":{
+                "comment": {
                     "type": "string",
                     "description": "A comment on this resource. This is not intended to be sent to translators."
                 }
@@ -344,7 +344,7 @@
             "description": "Metadata for a message.",
             "additionalProperties": false
         },
-        "^(?!@@).+$": {
+        "^(?!@).+$": {
             "type": "string",
             "description": "The ID of a message"
         }


### PR DESCRIPTION
Fixes #93 

`^(?!@@).+$` matches both "xxx" and "@xxx". In VS Code version prior to the `1.130`, this is not a issue.

But since I updated the VS Code to `1.130`, all metadate are required to be both `string` and `object`, which is impossible.

This PR update the schema to make sure the last `patternProperties` schema does not match metadata.

I have tested using the VS Code `1.129.1` + ARB Editor `0.2.2`, it does not show any warnings:

<img width="404" height="117" alt="image" src="https://github.com/user-attachments/assets/427d3468-a87a-41b3-8adc-c7b58b4d9bd4" />

While the same file shows the warnings:
<img width="703" height="193" alt="Image" src="https://github.com/user-attachments/assets/ec87dfdd-43d5-4103-a383-12cd537278e5" />

<img width="681" height="104" alt="Image" src="https://github.com/user-attachments/assets/65eada03-2239-4ebd-a996-ddec1f50b0a2" />

- [x] Tests pass
- [x] Appropriate changes to README are included in PR